### PR TITLE
8.7: permissions on new files for NetworkManager

### DIFF
--- a/docs/atoms_20_setup_and_demo/17_setup_duckiebot_c0wjd/1_6_duckiebot_initialization.md
+++ b/docs/atoms_20_setup_and_demo/17_setup_duckiebot_c0wjd/1_6_duckiebot_initialization.md
@@ -226,6 +226,10 @@ Save the following block as new file in `/etc/NetworkManager/system-connections/
     dns-search=
     method=auto
 
+Set the permissions on the new file to 0600.
+
+    sudo chmod 0600 /etc/NetworkManager/system-connections/eduroam
+
 ### Option 2.b): `eduroam` WiFi (UdeM/McGill instructions){status=draft}
 
 Save the following block as new file in `/etc/NetworkManager/system-connections/eduroam-![USERNAME]`:
@@ -270,7 +274,9 @@ where USERNAME is the your logged-in username in the duckiebot.
     dns-search=
     method=auto
 
+Set the permissions on the new file to 0600.
 
+    sudo chmod 0600 /etc/NetworkManager/system-connections/eduroam-![USERNAME]
 
 ### Option 3: custom WiFi {status=draft}
 
@@ -322,6 +328,10 @@ Save the following block as new file in `/etc/NetworkManager/system-connections/
     ip6-privacy=0
     method=auto
 
+
+Set the permissions on the new file to 0600.
+
+    sudo chmod 0600 /etc/NetworkManager/system-connections/BELL343
 
 ## Update the system
 


### PR DESCRIPTION
By default, new files in /etc/NetworkManager/system-connections/ are "group" and "all" readable.  From NetworkManager's documentation: " For security,  [NetworkManager] will  ignore  files that are readable or writeable by any user or group other than  root  since  private  keys  and passphrases may be stored in plaintext inside the file." (http://manpages.ubuntu.com/manpages/trusty/man5/NetworkManager.conf.5.html#contenttoc3).

For new files to work with NetworkManager, their permissions need to be set to 0600.