### PR TITLE
Update broken link.

### DIFF
--- a/docs/atoms_70_software_devel_guide/45-ROS-pkg_name.md
+++ b/docs/atoms_70_software_devel_guide/45-ROS-pkg_name.md
@@ -52,7 +52,7 @@ tells `catkin` to setup Python-related stuff for this package.
 
 See also: [ROS documentation about `setup.py`][setuppy]
 
-[setuppy]: http://docs.ros.org/api/catkin/html/user_guide/setup_dot_py.html)
+[setuppy]: http://docs.ros.org/api/catkin/html/user_guide/setup_dot_py.html
 
 ### `package.xml`
 


### PR DESCRIPTION
catkin steup.py instructions' link was broken due to an extra parenthesis