### PR TITLE
Add ImageMagick dependency to build instructions

### DIFF
--- a/docs/atoms_10_duckietown_meta/70_contrib/60_contributing_to_docs.md
+++ b/docs/atoms_10_duckietown_meta/70_contrib/60_contributing_to_docs.md
@@ -50,6 +50,7 @@ On Ubuntu 16.04, these are the dependencies to install:
     $ sudo apt install python-dev python-numpy python-matplotlib
     $ sudo apt install virtualenv
     $ sudo apt install bibtex2html pdftk
+    $ sudo apt install imagemagick
 
 
 


### PR DESCRIPTION
When compiling the documentation I encountered the following error after running `make master-clean master`:

```
rm -rf out/master

You need to install ImageMagick
Makefile:32: recipe for target 'check-programs' failed
make: *** [check-programs] Error 2
```

To fix it, I ran `sudo apt install imagemagick`.