### PR TITLE
close a window in Byobu

### DIFF
--- a/docs/atoms_60_software_reference/12_software_carpentry/40_byobu.md
+++ b/docs/atoms_60_software_reference/12_software_carpentry/40_byobu.md
@@ -54,7 +54,7 @@ Commands to use windows:
     <s><kbd>Ctrl</kbd>-<kbd>A</kbd> then a number</s>
 
     <s>Close window</s>
-    <s><kbd>F6</kbd></s>
+    <s><kbd>Ctrl</kbd>-<kbd>F6</kbd></s>
     <s></s>
 
     <s>Rename window </s>


### PR DESCRIPTION
The command to close a window in Byobu should be Ctrl+F6 instead of F6