### PR TITLE
Small fix on fig:oneshot1_all label

### DIFF
--- a/docs/atoms_20_setup_and_demo/17_setup_duckiebot_DB17-jwd/2_2_2_camera_calibration.md
+++ b/docs/atoms_20_setup_and_demo/17_setup_duckiebot_DB17-jwd/2_2_2_camera_calibration.md
@@ -303,7 +303,7 @@ localizes perfectly.
 
 <div figure-id="fig:oneshot1_all">
     <img style='width:90%' src="oneshot1_all.jpg"/>
-    <figcaption>Output when camera not properly calibrated.</figcaption>
+    <figcaption>Output when camera is properly calibrated.</figcaption>
 </div>
 
 ### Example of failure


### PR DESCRIPTION
There was a small typo in that figure label.